### PR TITLE
Small typo to fix bug in numerical stability

### DIFF
--- a/jax_loss/classification.py
+++ b/jax_loss/classification.py
@@ -12,7 +12,7 @@ def bce_w_logits(x, y, weight=None, average=True):
     :param average: Boolean to average resulting loss vector
     :return: Scalar value
     """
-    max_val = np.clip(x, 0, None)
+    max_val = np.clip(-x, 0, None)
     loss = x - x * y + max_val + np.log(np.exp(-max_val) + np.exp((-x - max_val)))
 
     if weight is not None:


### PR DESCRIPTION
One has to clip -x, not x. Otherwise, it is numerically unstable. Checked on my own data, and the link mentioned on line 7 also uses -x.

This bug only was only making it less stable, not incorrect.